### PR TITLE
Standardise file names and location

### DIFF
--- a/src/bpkg-build/bpkg-build
+++ b/src/bpkg-build/bpkg-build
@@ -44,6 +44,23 @@ fi
 NAME=`grep ^Package: debian/control`
 NAME=${NAME#Package: }
 
+# The architecture is specified in the control file,
+# or supplied at build time for multi-arch pacakges.
+CTL_ARCH=`grep ^Architecture: debian/control`
+CTL_ARCH=${CTL_ARCH#Architecture :}
+
+if [ -z "$ARCHITECTURE" -a -z "$CTL_ARCH" ]
+then
+	printf "No architecture supplied in env or control file" >&2
+fi
+
+if [ -n "$ARCHITECTURE" -a -n "$CTL_ARCH" -a "$ARCHITECTURE" != "$CTL_ARCH" ]
+then
+	printf "Architecture supplied on command like (%s) does not match that in control file (%s)\n" "$CTL_ARCH" "$ARCHITECTURE" >&2
+fi
+
+ARCHITECTURE=${ARCHITECTURE:-${CTL_ARCH}}
+
 # The version of a package can be defined in either the
 # control file, or given on the command line.
 # In the event both are supplied, they are required to match.
@@ -70,9 +87,10 @@ DESTINATION=${3:-$DIR}
 # Seal all variables
 readonly NAME
 readonly VERSION
+readonly ARCHITECTURE
 readonly DESTINATION
 
-if [ -e "${DESTINATION}/${NAME}_${VERSION}.deb" ]
+if [ -e "${DESTINATION}/${NAME}_${VERSION}_${ARCHITECTURE}.deb" ]
 then
 	printf "${NAME}:${VERSION} already built\n" >&2
 	exit 0
@@ -129,13 +147,18 @@ do
 	printf "%s\n" "$LINE" >&3
 done <"debian/control.orig"
 
+if [ -z "${CTL_ARCH}" ]
+then
+	printf "Architecture: %s\n" "$ARCHITECTURE" >&3
+fi
+
 printf "Version: %s\n" "$VERSION" >&3
 printf "Installed-Size: %d\n" "$SIZE" >&3
 
 exec 3>&-
 
 mkdir -vp "${DESTINATION}"
-make-package . "${DESTINATION}/${NAME}_${VERSION}.deb"
+make-package . "${DESTINATION}/${NAME}_${VERSION}_${ARCHITECTURE}.deb"
 STATUS=$?
 
 mv "debian/control.orig" "debian/control" || {

--- a/src/bpkg-build/bpkg-build
+++ b/src/bpkg-build/bpkg-build
@@ -30,12 +30,23 @@ cd "$DIR"
 if [ ! -r debian/control ]
 then
 	printf "No control file\n" >&2
+
+	if [ -z "$1" ]
+	then
+		printf "Usage: %s [package directory] [version] [destination]\n" "$0" >&2
+	fi
+
 	exit 1
 fi
 
+# The name of the package can only be set from the control
+# file with the Package: line.
 NAME=`grep ^Package: debian/control`
 NAME=${NAME#Package: }
 
+# The version of a package can be defined in either the
+# control file, or given on the command line.
+# In the event both are supplied, they are required to match.
 VERSION=`grep ^Version: debian/control`
 VERSION=${VERSION#Version: }
 
@@ -67,6 +78,8 @@ then
 	exit 0
 fi
 
+# Supply --quiet to all make(1) calls unless we have an interactive
+# terminal; this is intended to keep automated builds readable.
 test -t 1 -a -t 2 && QUIET= || QUIET=--quiet
 
 bpkg-checkbuilddeps && \

--- a/src/bpkg-build/bpkg-build
+++ b/src/bpkg-build/bpkg-build
@@ -41,7 +41,7 @@ NAME=`grep ^Package: debian/control`
 NAME=${NAME#Package: }
 
 # The architecture is specified in the control file,
-# or supplied at build time for multi-arch pacakges.
+# or supplied at build time for multi-arch packages.
 CTL_ARCH=`grep ^Architecture: debian/control`
 CTL_ARCH=${CTL_ARCH#Architecture :}
 
@@ -77,7 +77,7 @@ fi
 # Finalise the determined version
 VERSION=${VERSION:-$2}
 
-# Determins where the file is to be written to
+# Determines where the file is to be written to
 DESTINATION=${3:-$DIR}
 
 # Seal all variables

--- a/src/bpkg-build/bpkg-build
+++ b/src/bpkg-build/bpkg-build
@@ -50,13 +50,18 @@ then
 	printf "Version in debian/control does not match CLI argument\n" >&2
 fi
 
+# Finalise the determined version
 VERSION=${VERSION:-$2}
+
+# Determins where the file is to be written to
+DESTINATION=${3:-$DIR}
 
 # Seal all variables
 readonly NAME
 readonly VERSION
+readonly DESTINATION
 
-if [ -e "${NAME}_${VERSION}.deb" ]
+if [ -e "${DESTINATION}/${NAME}_${VERSION}.deb" ]
 then
 	printf "${NAME}:${VERSION} already built\n" >&2
 	exit 0
@@ -116,7 +121,8 @@ printf "Installed-Size: %d\n" "$SIZE" >&3
 
 exec 3>&-
 
-make-package . "${NAME}_${VERSION}.deb"
+mkdir -vp "${DESTINATION}"
+make-package . "${DESTINATION}/${NAME}_${VERSION}.deb"
 STATUS=$?
 
 mv "debian/control.orig" "debian/control" || {

--- a/src/bpkg-build/bpkg-build
+++ b/src/bpkg-build/bpkg-build
@@ -23,11 +23,6 @@ check xz
 check sha256sum
 check sha512sum
 
-mkdir -p "${POOLDIR}" || {
-	printf "Unable to make pool directory %s\n" "$POOLDIR" >&2
-	exit 1
-}
-
 DIR=${1:-.}
 
 cd "$DIR"
@@ -57,15 +52,15 @@ fi
 
 VERSION=${VERSION:-$2}
 
-mkdir -vp "${POOLDIR}/${NAME}/${VERSION}" || {
-	printf "Unable to make pool directory %s\n" "${POOLDIR}/${NAME}/${VERSION}" >&2
-	exit 1
-}
+# Seal all variables
+readonly NAME
+readonly VERSION
 
-test -e "${POOLDIR}/${NAME}/${VERSION}/${NAME}_${VERSION}.deb" && {
+if [ -e "${NAME}_${VERSION}.deb" ]
+then
 	printf "${NAME}:${VERSION} already built\n" >&2
 	exit 0
-}
+fi
 
 test -t 1 -a -t 2 && QUIET= || QUIET=--quiet
 
@@ -121,7 +116,7 @@ printf "Installed-Size: %d\n" "$SIZE" >&3
 
 exec 3>&-
 
-make-package . "${POOLDIR}/${NAME}/${VERSION}/${NAME}_${VERSION}.deb"
+make-package . "${NAME}_${VERSION}.deb"
 STATUS=$?
 
 mv "debian/control.orig" "debian/control" || {

--- a/src/bpkg-build/bpkg-build
+++ b/src/bpkg-build/bpkg-build
@@ -10,10 +10,6 @@ check()
 	exit 255
 }
 
-test -r /etc/bpkg.conf && {
-	. /etc/bpkg.conf
-}
-
 check make
 check bpkg-checkbuilddeps
 check make-package


### PR DESCRIPTION
Change bpkg-build to output files in the package's directory using the standard `{PACKAGE}_{VERSION}_{ARCHITECTURE}.deb` filename format.

This introduces a check that the `Architecture:` of a package is defined in either the `control` file, or in the `ARCHITECTURE` environment variable. If it is supplied in both, they must match.