### PR TITLE
bpkg-build: Fix bug in reading Architecture header

### DIFF
--- a/src/bpkg-build/bpkg-build
+++ b/src/bpkg-build/bpkg-build
@@ -43,7 +43,7 @@ NAME=${NAME#Package: }
 # The architecture is specified in the control file,
 # or supplied at build time for multi-arch packages.
 CTL_ARCH=`grep ^Architecture: debian/control`
-CTL_ARCH=${CTL_ARCH#Architecture :}
+CTL_ARCH=${CTL_ARCH#Architecture: }
 
 if [ -z "$ARCHITECTURE" -a -z "$CTL_ARCH" ]
 then


### PR DESCRIPTION
bpkg-build was building packages like 'foo_1.0.1-1_Architecture: all.deb'. This is because of a typo, causing the wrong prefix to be stripped, and so not stripping it.